### PR TITLE
Small changes I needed to build the project on Ubuntu 10.10.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -78,11 +78,11 @@
 NDMOS_OPTIONS = -DNDMOS_CONST_NDMJOBLIB_REVISION='"(spinnaker-2003)"'
 
 #Linux
-LIBS=
+LIBS=-lglib-2.0
 #LIBS= /home/ern/sources/DMALLOC/dmalloc-4.8.2/libdmalloc.a
 DEFS = $(NDMOS_ID) $(NDMOS_OPTIONS)
 # gcc gives unused-value warnings for *_xdr.c, which is generated code
-CFLAGS = -g $(DEFS) -Wall -O -Werror -Wno-unused-value -D_LARGEFILE64_SOURCE
+CFLAGS = -g $(DEFS) -Wall -O -Wno-unused-value -D_LARGEFILE64_SOURCE
 
 #FreeBSD
 #LIBS= -lcam

--- a/src/ndma_tape.c
+++ b/src/ndma_tape.c
@@ -256,6 +256,7 @@ ndmta_mover_start_active (struct ndm_session *sess)
 void
 ndmta_mover_stop (struct ndm_session *sess)
 {
+	struct ndm_tape_agent *	ta = &sess->tape_acb;
 	/* don't call ndmta_init_mover_state here, because that incorrectly
 	 * resets the record_size */
 	ta->mover_state.state = NDMP9_MOVER_STATE_IDLE;


### PR DESCRIPTION
gcc won't build this project with -Werror, there was a missing variable in ndma_tape.c and glib-2.0 was missing from the linker path.

(Hello, again. I promise I'm not stalking you, I just happened to have dug into an NDMP hole today and this project showed up in a search! Small world.)
